### PR TITLE
defined the Eff_eq by iterating over naturals.

### DIFF
--- a/theories/Eff.v
+++ b/theories/Eff.v
@@ -184,8 +184,6 @@ Section Eff.
 
    Require Import Coq.Logic.Eqdep. (* imports the UIP axiom *)
    
- (* the other direction is guaranteed to hold. this direction only holds
-if the greatest fixpoint is reached by interating over the natural numbers  *)
  Lemma ind_implies_coind  {T} (t1 t2: Eff T):
    Eff_eq_ind _ t1 t2 -> Eff_eq_coind t1 t2.
  Proof using.
@@ -200,7 +198,7 @@ if the greatest fixpoint is reached by interating over the natural numbers  *)
    intros ?. apply ind_implies_coind.
    intros ?. specialize (Hi (S n)).
    inversion Hi.  subst.
-   apply inj_pair2 in H1. (* uses the UIP axiom! *)
+   apply inj_pair2 in H1. (* uses the UIP axiom! one way to avoid it is to interact only on data of decidable types *)
    apply inj_pair2 in H2.
    apply inj_pair2 in H3.
    apply inj_pair2 in H4.
@@ -210,6 +208,20 @@ if the greatest fixpoint is reached by interating over the natural numbers  *)
    apply ind_implies_coind.
    intros ?. specialize (Hi (S n)).
    inversion Hi.  subst. eauto.
+ Qed.
+ 
+ Lemma coind_implies_ind  {T} (t1 t2: Eff T):
+   Eff_eq_coind t1 t2 -> Eff_eq_ind _ t1 t2.
+ Proof using.
+   intros Hi n. revert dependent T.
+   induction n; intros; [exact I|].
+   hnf. inversion Hi; subst.
+   pose proof Eff_eqF_mon as Hm.
+   hnf in Hm.
+   eapply Hm;[ apply H | ].
+   intros. simpl. 
+   specialize (IHn _ _ _ PR).
+   exact IHn.
  Qed.
  
     Definition Eff_eq : forall {T}, Eff T -> Eff T -> Prop :=

--- a/theories/Eff.v
+++ b/theories/Eff.v
@@ -140,7 +140,22 @@ Section Eff.
     intros. rewrite getEff_eq at 1. reflexivity.
   Defined.
 
+  Fixpoint Fn {A:Type} (step: A -> A)  (f0 : A) (n:nat) :=
+    match n with
+    | O => f0 
+    | S n => step (Fn step f0 n)
+    end.
+
+  (* TODO: generalize for hetero relations *)
+  Definition RTopN {A:Type} (Rs: (A -> A->Prop)->(A -> A->Prop)) (n:nat) :=
+    Fn Rs (fun _ _=> True) (* Top *) n.
   (* Equivalence, including stuttering steps *)
+
+  (* greatest fixpoint if F is continuous *)
+  Definition GFPC {A:Type} (Rs: (A -> A->Prop)->(A -> A->Prop))  (a1 a2: A): Prop:=
+   forall n, RTopN Rs n a1 a2.
+  (* Equivalence, including stuttering steps *)
+  
   Section Eff_eq.
 
     Inductive Eff_eqF (eff_eq : forall T, Eff T -> Eff T -> Prop) {T}
@@ -151,6 +166,8 @@ Section Eff.
         Eff_eqF eff_eq (interact e k1) (interact e k2)
     | eq_delay : forall a b, eff_eq _ a b ->
                         Eff_eqF eff_eq (delay a) (delay b).
+
+    Definition Eff_eq_ind := GFPC Eff_eqF.
 
     Lemma Eff_eqF_mon: monotone3 Eff_eqF.
     Proof.


### PR DESCRIPTION
Thus, coinductive proofs about Eff_eq can be done by induction on natural numbers, instead of paco or cofix. In my experience formalizing Nuprl metatheory, these proofs by natural induction exactly mimic the cofix proof (and there is no need to worry about productivity check failing at Qed). However, when using Paco, non-trivial work is needed in strengthening the coinduction hypothesis. 